### PR TITLE
fix: getUTCDate error with empty input

### DIFF
--- a/lib/date.js
+++ b/lib/date.js
@@ -15,10 +15,10 @@ const getYear = (julianYearLastDigit) => {
   }
   return currentYear;
 };
-
 const iataJulianDateRegexp = /^(?<julianYearLastDigit>\d)?(?<julianDayOfYear>\d{3})$/;
 
 const getUTCDate = (input) => {
+  if (!input || !input.length) return input;
   const { groups: { julianYearLastDigit, julianDayOfYear } } = input.match(iataJulianDateRegexp);
   const year = getYear(julianYearLastDigit);
   const date = new Date(Date.UTC(year, 0, 0));

--- a/lib/date.test.js
+++ b/lib/date.test.js
@@ -15,6 +15,10 @@ describe('[unit] lib', () => {
     clock.restore();
   });
   describe('getUTCDate', () => {
+    it('must empty', () => {
+      const date = getUTCDate('');
+      expect(date).to.be.eq('');
+    });
     it('must return 7th of july of the current year', () => {
       const date = getUTCDate('250');
       expect(date.toISOString()).to.be.eq('2023-09-07T00:00:00.000Z');

--- a/test/bcbp.unit.test.js
+++ b/test/bcbp.unit.test.js
@@ -4,7 +4,8 @@ const { parseBCBP } = require('../lib/bcbp');
 const mock = {
   bcbp1: 'M1PADRONGOMEZ/CARLO   EK51KC  MADSPCIB 3842 117N016B0109 14B>5181WM8117BIB              2A0752376813598 2   IB IB00000000           8  ',
   bcbp2: 'M1ASKREN/TEST         EA272SL ORDNRTUA 0881 007F002K0303 15C>3180 K6007BUA              2901624760758980 UA UA EY975897            *30600    09  UAG    ',
-  bcbp3: 'M1RIVERACARDENAS/YEL  ENP5EY  MADSJOIB 6317 031N034A0076 14B>5182WM2030BIB              2A0757652331574 2                              '
+  bcbp3: 'M1RIVERACARDENAS/YEL  ENP5EY  MADSJOIB 6317 031N034A0076 14B>5182WM2030BIB              2A0757652331574 2                              ',
+  bcbp4: 'M1PORTASSE/MICHEL     E       AMSCDGKL 1227 044M019A0001 300'
 };
 
 describe('[unit] bcbp', () => {
@@ -39,6 +40,18 @@ describe('[unit] bcbp', () => {
       const currentYear = new Date().getFullYear();
       expect(result.flight_date.getFullYear()).to.be.greaterThanOrEqual(currentYear);
       expect(result.date_pass_issue.getFullYear()).to.be.greaterThanOrEqual(currentYear);
+    });
+
+    it('must work with short BCPs', () => {
+      const result = parseBCBP(mock.bcbp4, true);
+      const keys = ['passenger', 'pnr', 'origin', 'destination',
+        'airline', 'flight_number', 'flight_date', 'seat', 'checkin_number', 'flight_date', 'date_pass_issue'];
+      expect(result).to.include.keys(keys);
+      Object.keys(keys).forEach((item) => {
+        expect(item).to.not.be.eq(undefined);
+      });
+      const currentYear = new Date().getFullYear();
+      expect(result.flight_date.getFullYear()).to.be.greaterThanOrEqual(currentYear);
     });
   });
 });

--- a/test/bcbp.unit.test.js
+++ b/test/bcbp.unit.test.js
@@ -42,7 +42,7 @@ describe('[unit] bcbp', () => {
       expect(result.date_pass_issue.getFullYear()).to.be.greaterThanOrEqual(currentYear);
     });
 
-    it('must work with short BCPs', () => {
+    it('must work with short BCBPs', () => {
       const result = parseBCBP(mock.bcbp4, true);
       const keys = ['passenger', 'pnr', 'origin', 'destination',
         'airline', 'flight_number', 'flight_date', 'seat', 'checkin_number', 'flight_date', 'date_pass_issue'];

--- a/test/bcbp.unit.test.js
+++ b/test/bcbp.unit.test.js
@@ -52,6 +52,7 @@ describe('[unit] bcbp', () => {
       });
       const currentYear = new Date().getFullYear();
       expect(result.flight_date.getFullYear()).to.be.greaterThanOrEqual(currentYear);
+      expect(result.date_pass_issue).to.be.eq('');
     });
   });
 });


### PR DESCRIPTION
# Description 
When using the sample Aztec code of the "BAR CODED BOARDING PASS (BCBP) IMPLEMENTATION GUIDE" of IATA it fails.

![image](https://github.com/cluny85/bcbp-parser/assets/14946058/2d6ad5a4-c9ab-4f81-be68-e1fe45c11cff)

![image](https://github.com/cluny85/bcbp-parser/assets/14946058/19e9a68f-708c-4fc8-bea1-30f35bc10a9b)

# Fixes
- Fix error if empty string is provided to the `getUTCDate` function.

